### PR TITLE
feat: use og service for image meta

### DIFF
--- a/blog/.vuepress/theme/util/meta.js
+++ b/blog/.vuepress/theme/util/meta.js
@@ -7,7 +7,7 @@ const defaultMetas = {}
 const resolveURL = (base, path) =>
   `${_.trimEnd(base, '/')}/${_.trimStart(path, '/')}`
 
-const ogImageURL = 'https://og-image.checkly.vercel.app'
+const ogImageURL = 'https://og-image.theheadless.dev'
 
 const getOptionDefaults = () => {
   return {


### PR DESCRIPTION
Not a big fan of this solution, but couldn't find a standard way to change the image tag dynamically on vuepress. 
The other option is to set the link on each one of the posts, like this:

```
meta:
  - name: og:image
    content: https://og-image.checkly.vercel.app/**Starting%20the%20browser%20and%20navigating%20to%20a%20webpage**.png?theme=light&md=1&fontSize=120px
```