### PR TITLE
fix: make right nav sticky but blocking the width to center

### DIFF
--- a/blog/.vuepress/theme/components/Toc.vue
+++ b/blog/.vuepress/theme/components/Toc.vue
@@ -1,29 +1,30 @@
 <template>
-  <Sticker
+  <div
     v-if="visible"
     class="vuepress-toc"
     v-bind="$attrs"
   >
-    <div
-      v-for="(item, index) in $page.headers"
-      ref="chairTocItem"
-      :key="index"
-      class="vuepress-toc-item"
-      :class="[
-        `vuepress-toc-h${item.level}`,
-        { active: activeIndex === index },
-      ]"
-    >
-      <a
-        :href="`#${item.slug}`"
-        :title="item.title"
-      >{{ item.title }}</a>
+    <div class="vuepress-toc-content">
+      <div
+        v-for="(item, index) in $page.headers"
+        ref="chairTocItem"
+        :key="index"
+        class="vuepress-toc-item"
+        :class="[
+          `vuepress-toc-h${item.level}`,
+          { active: activeIndex === index },
+        ]"
+      >
+        <a
+          :href="`#${item.slug}`"
+          :title="item.title"
+        >{{ item.title }}</a>
+      </div>
     </div>
-  </Sticker>
+  </div>
 </template>
 
 <script>
-import Sticker from './Sticker.vue'
 let initTop
 
 // get offset top
@@ -36,10 +37,6 @@ function getAbsoluteTop (dom) {
 }
 
 export default {
-  components: {
-    Sticker
-  },
-
   data () {
     return {
       activeIndex: 0
@@ -144,20 +141,21 @@ export default {
   display none !important
 
 .vuepress-toc
-  position fixed
   display none
   max-height 100vh
-  max-width 220px
+  width 220px
   overflow-y auto
   padding-top 5rem
   top 0
-  right 2rem
   box-sizing border-box
   z-index 0
 
+  .vuepress-toc-content
+    position fixed
+
   .vuepress-toc-item
     position relative
-    padding 0.1rem 0.6rem 0.1rem 1.5rem
+    padding 5px 0
     line-height 1.5rem
     overflow hidden
 

--- a/blog/.vuepress/theme/layouts/Post.vue
+++ b/blog/.vuepress/theme/layouts/Post.vue
@@ -3,6 +3,7 @@
     <article
       itemscope
       itemtype="https://schema.org/BlogPosting"
+      class="post-article"
     >
       <header>
         <h1
@@ -52,15 +53,19 @@ export default {
 @require '../styles/wrapper.styl'
 
 .post
+  display flex
+
+.post-article
   @extend $wrapper
-  padding-top: 0
+  padding-top: 25px
   font-size 16px
   letter-spacing 0
   color $textColor
-  position relative
   max-width 730px
 
 @media (max-width: $MQMobile)
   .post-title
     margin-top 0
+  .post
+    display block
 </style>


### PR DESCRIPTION
Center content correctly by fixing the right navigation to be sticky but at the same time to count as part of the width of the screen.

![Screenshot 2020-08-12 at 11 24 57](https://user-images.githubusercontent.com/1178139/89998957-7aaf5880-dc8e-11ea-80d8-f9093390c40f.png)
