### PR TITLE
fix: redirect when html extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ blog/.vuepress/dist
 .idea
 .eslintcache
 .DS_Store
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "rewrites": [
+    {
+      "source": "/posts/:post.html",
+      "destination": "/posts/:post"
+    }
+  ]
+}


### PR DESCRIPTION
When the URL is postfixed with `.html` we redirect to the correct URL

Closes #62 