### PR TITLE
fix(footer): sidebar was not visible due scrolling

### DIFF
--- a/blog/.vuepress/theme/styles/index.styl
+++ b/blog/.vuepress/theme/styles/index.styl
@@ -153,7 +153,7 @@ th, td
   background-color $queenLightest
   width $sidebarWidth
   position fixed
-  z-index 10
+  z-index 20
   margin 0
   top $navbarHeight
   left 0


### PR DESCRIPTION
The footer has a z-index of 10 and the sidebar too. This lead to the follow behaviour if the user has scrolled down entirely:

![image](https://user-images.githubusercontent.com/17984549/93137381-aaaea900-f6dd-11ea-9db3-9ec96d4731ae.png)

After the change it looks like that:

![image](https://user-images.githubusercontent.com/17984549/93137409-b4d0a780-f6dd-11ea-8b7f-c6147fbc5e0c.png)


(on the posts page: https://guides-checklyhq-com-git-fork-mxschmitt-patch-1.checkly.vercel.app/posts/)