### PR TITLE
fix: toc break text in multiple lines

### DIFF
--- a/blog/.vuepress/theme/components/Toc.vue
+++ b/blog/.vuepress/theme/components/Toc.vue
@@ -170,7 +170,6 @@ export default {
       transition color 0.3s
       overflow hidden
       text-overflow ellipsis
-      white-space nowrap
 
     &.active
       a


### PR DESCRIPTION
Break the table of content into multiple lines.

![Screenshot 2020-10-05 at 14 45 04](https://user-images.githubusercontent.com/1178139/95082815-edcbcd00-071b-11eb-940c-129ac43702f1.png)
