### PR TITLE
fix: footer at smaller widths

### DIFF
--- a/blog/.vuepress/theme/components/Footer.vue
+++ b/blog/.vuepress/theme/components/Footer.vue
@@ -166,6 +166,7 @@ export default {
   }
   &__container {
     max-width: 1150px;
+    padding: 0 0 0 240px;
     margin: 0 auto;
     display: flex;
   }

--- a/blog/.vuepress/theme/components/Footer.vue
+++ b/blog/.vuepress/theme/components/Footer.vue
@@ -176,7 +176,7 @@ export default {
     letter-spacing: 0.4px;
     color: #FF4949;
     font-weight: bold;
-    min-width: 350px;
+    min-width: 270px;
     text-align: right;
     margin-right: 40px;
   }

--- a/blog/.vuepress/theme/components/Sidebar.vue
+++ b/blog/.vuepress/theme/components/Sidebar.vue
@@ -68,6 +68,25 @@ export default {
       line-height 1.25rem
       font-size 1.1em
       padding 0.5rem 0 0.5rem 1.5rem
+  &::-webkit-scrollbar-track,
+  &::-webkit-scrollbar-track,
+  &::-webkit-scrollbar-track {
+    border-radius: 10px;
+    background-color: transparent;
+  }
+  &::-webkit-scrollbar,
+  &::-webkit-scrollbar,
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+    background-color: transparent;
+  }
+  &::-webkit-scrollbar-thumb,
+  &::-webkit-scrollbar-thumb,
+  &::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background-color: $queenLighter;
+  }
   & > .sidebar-links
     padding 1.5rem 0 0 0
     & > li > a.sidebar-link

--- a/blog/.vuepress/theme/components/Sidebar.vue
+++ b/blog/.vuepress/theme/components/Sidebar.vue
@@ -68,21 +68,15 @@ export default {
       line-height 1.25rem
       font-size 1.1em
       padding 0.5rem 0 0.5rem 1.5rem
-  &::-webkit-scrollbar-track,
-  &::-webkit-scrollbar-track,
   &::-webkit-scrollbar-track {
     border-radius: 10px;
     background-color: transparent;
   }
-  &::-webkit-scrollbar,
-  &::-webkit-scrollbar,
   &::-webkit-scrollbar {
     width: 8px;
     height: 8px;
     background-color: transparent;
   }
-  &::-webkit-scrollbar-thumb,
-  &::-webkit-scrollbar-thumb,
   &::-webkit-scrollbar-thumb {
     border-radius: 10px;
     background-color: $queenLighter;


### PR DESCRIPTION
1. I was browsing and noticed that at widths > 720px and < ~1400px the sidebar was covering some of the "Who's running this?" text.

![image](https://user-images.githubusercontent.com/7415984/99292694-de26c480-2841-11eb-9937-39252826d737.png)

Now it is taking into account the width of the sidebar and centering the rest of the content in the remaining space.

![image](https://user-images.githubusercontent.com/7415984/99292972-44134c00-2842-11eb-9732-a3bf7b838590.png)

---

2. Also the last commit just updated the styling of the scrollbar a bit, feel free to drop that commit if you guys don't like it.

Before:
![image](https://user-images.githubusercontent.com/7415984/99293986-b59fca00-2843-11eb-9c17-dbfa31b8f79e.png)

After: 
![image](https://user-images.githubusercontent.com/7415984/99293999-bb95ab00-2843-11eb-9772-0cdd17db0ff6.png)
