### PR TITLE
fix: use client-only when v-html present

### DIFF
--- a/blog/.vuepress/theme/components/Icon.vue
+++ b/blog/.vuepress/theme/components/Icon.vue
@@ -1,8 +1,10 @@
 <template>
-  <div
-    class="icon"
-    v-html="getSvg()"
-  />
+  <client-only>
+    <div
+      class="icon"
+      v-html="getSvg()"
+    />
+  </client-only>
 </template>
 
 <script>

--- a/blog/.vuepress/theme/layouts/Layout.vue
+++ b/blog/.vuepress/theme/layouts/Layout.vue
@@ -40,12 +40,13 @@
         </header>
 
         <!-- eslint-disable vue/no-v-html -->
-        <p
-          v-if="page.excerpt"
-          class="ui-post-summary"
-          itemprop="description"
-          v-html="page.excerpt"
-        />
+        <client-only v-if="page.excerpt">
+          <p
+            class="ui-post-summary"
+            itemprop="description"
+            v-html="page.excerpt"
+          />
+        </client-only>
         <!-- eslint-enable vue/no-v-html -->
         <p
           v-else


### PR DESCRIPTION
Use `client-only` when `v-html` is used to avoid hydration issues, more info here https://github.com/vuejs/vuepress/issues/1692

Closes #85 
